### PR TITLE
catching up (#1)

### DIFF
--- a/Install-LatestDbaDatabase.ps1
+++ b/Install-LatestDbaDatabase.ps1
@@ -40,7 +40,7 @@ foreach($instance in $instanceName) {
     $fileList = Get-ChildItem -Path .\tables -Recurse
     Foreach ($file in $fileList){
         Write-Verbose $file.FullName
-        Invoke-Sqlcmd -ServerInstance $instance -Database DBA -InputFile $file.FullName
+        Invoke-Sqlcmd -ServerInstance $instance -Database DBA -InputFile $file.FullName -QueryTimeout 300
     }
     #Then scalar functions
     Write-Verbose "`n        ***Creating/Updating Scalar Functions `n"

--- a/functions-scalar/dbo.AGDbRole_Get.sql
+++ b/functions-scalar/dbo.AGDbRole_Get.sql
@@ -18,10 +18,9 @@ EXAMPLES:
 MODIFICATIONS:
     YYYYMMDD - 
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 AS
 BEGIN

--- a/functions-scalar/dbo.EmailCss_Get.sql
+++ b/functions-scalar/dbo.EmailCss_Get.sql
@@ -17,10 +17,9 @@ PARAMETERS
 MODIFICATIONS:
     YYYYMMDDD - Initials - Description of changes
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 BEGIN
     DECLARE @Style nvarchar(max),

--- a/functions-scalar/dbo.EmailServerInfo_Get.sql
+++ b/functions-scalar/dbo.EmailServerInfo_Get.sql
@@ -21,10 +21,9 @@ PARAMETERS
 MODIFICATIONS:
     YYYYMMDDD - Initials - Description of changes
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 BEGIN
     DECLARE @ServerInfo nvarchar(max);

--- a/functions-tvfs/dbo.AgentJob_Status.sql
+++ b/functions-tvfs/dbo.AgentJob_Status.sql
@@ -17,10 +17,9 @@ EXAMPLES:
 MODIFICATIONS:
     20160218 - More info here: https://am2.co/2016/02/xp_sqlagent_enum_jobs_alt/
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 AS
 RETURN

--- a/functions-tvfs/dbo.ParseFilePath.sql
+++ b/functions-tvfs/dbo.ParseFilePath.sql
@@ -18,10 +18,9 @@ EXAMPLES:
 MODIFICATIONS:
     20160218 - 
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2018 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 AS
 RETURN

--- a/functions-tvfs/dbo.fn_split.sql
+++ b/functions-tvfs/dbo.fn_split.sql
@@ -20,10 +20,9 @@ EXAMPLES:
 MODIFICATIONS:
     YYYYMMDD -
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 AS
 RETURN

--- a/stored-procedures/dbo.Alert_Blocking.sql
+++ b/stored-procedures/dbo.Alert_Blocking.sql
@@ -44,10 +44,9 @@ MODIFICATIONS:
     20171210 - AM2 - Add Debug Mode = 2 to return the Email Body as a chunk of HTML instead of emailing it.
 
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 --READ UNCOMMITTED, since we're dealing with blocking, we don't want to make things worse.

--- a/stored-procedures/dbo.Check_AgLatency.sql
+++ b/stored-procedures/dbo.Check_AgLatency.sql
@@ -20,6 +20,10 @@ EXAMPLES:
 MODIFICATIONS:
     20140804 - Start tracking Hardened LSN from DMV each time sproc runs. 
     20150107 - Add calculation for "minutes behind" to show how far behind primary a DB is
+**************************************************************************************************
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 

--- a/stored-procedures/dbo.Check_Blocking.sql
+++ b/stored-procedures/dbo.Check_Blocking.sql
@@ -12,7 +12,7 @@ CREATED: 20141218
 
 PARAMETERS
 * @BlockingDurationThreshold - seconds - Shows blocked sessions that have been waiting longer than this many seconds.
-* @BlockedSessionThreshold - Shows blocking only when the number of blocked sessions is this number of higher.
+* @BlockedSessionThreshold - Shows blocking only when the number of blocked sessions is this number or higher.
 **************************************************************************************************
 MODIFICATIONS:
     20141222 - AM2 - Parse out the Hex jobid in ProgramName & turn into the Job Name.
@@ -29,10 +29,9 @@ MODIFICATIONS:
     20171210 - AM2 - Add Debug Mode = 2 to return the Email Body as a chunk of HTML instead of emailing it.
 
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 --READ UNCOMMITTED, since we're dealing with blocking, we don't want to make things worse.

--- a/stored-procedures/dbo.Check_DriveSpace.sql
+++ b/stored-procedures/dbo.Check_DriveSpace.sql
@@ -16,10 +16,9 @@ PARAMETERS
 MODIFICATIONS:
     YYYYMMDDD - Initials - Description of changes
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 DECLARE @database_id int,

--- a/stored-procedures/dbo.Check_FileSize.sql
+++ b/stored-procedures/dbo.Check_FileSize.sql
@@ -36,10 +36,9 @@ MODIFICATIONS:
        20140101 - Initials - Modification description
        
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 

--- a/stored-procedures/dbo.Check_LogVLF.sql
+++ b/stored-procedures/dbo.Check_LogVLF.sql
@@ -22,10 +22,9 @@ EXAMPLES:
 MODIFICATIONS:
     20150107 - 
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 

--- a/stored-procedures/dbo.Check_OpenTransactions.sql
+++ b/stored-procedures/dbo.Check_OpenTransactions.sql
@@ -4,7 +4,8 @@ GO
 
 
 ALTER PROCEDURE dbo.Check_OpenTransactions
-    @DurationThreshold smallint = 1
+    @DurationThreshold smallint = 1,
+    @OnlySleepingSessions bit = 0
 AS
 /*************************************************************************************************
 AUTHOR: Andy Mallon
@@ -16,6 +17,7 @@ CREATED: 20141218
 PARAMETERS
 * @DurationThreshold - minutes - Alters when database locks have been holding log space
                        for this many minutes.
+* @OnlySleepingSessions - bit - Only show sessions that are sleeping
 **************************************************************************************************
 MODIFICATIONS:
     20141222 - AM2 - Parse out the Hex jobid in ProgramName & turn into the Job Name.
@@ -28,12 +30,11 @@ MODIFICATIONS:
                           - If a procedure is running, this is the specific statement within that proc
                3) InputBuffer - This is the output from DBCC INPUTBUFFER
                           - If a procedure is running, this is the EXEC statement
-
+    20190401 - AM2 - Add filter to only include sleeping sessions in results
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
@@ -113,6 +114,7 @@ JOIN sys.dm_tran_database_transactions dt ON dt.transaction_id = st.transaction_
 LEFT JOIN sys.dm_exec_requests r ON r.session_id = s.session_id
 OUTER APPLY sys.dm_exec_sql_text (r.sql_handle) t
 WHERE dt.database_transaction_state NOT IN (3) -- 3 means transaction has been initialized but has not generated any log records. Ignore it
+AND (@OnlySleepingSessions = 0 OR s.status = 'sleeping')
 AND COALESCE(dt.database_transaction_begin_time,s.last_request_start_time) < DATEADD(mi,-1*@DurationThreshold ,GETDATE());
 
 -- Grab the input buffer for all sessions, too.

--- a/stored-procedures/dbo.Check_SprocPerf.sql
+++ b/stored-procedures/dbo.Check_SprocPerf.sql
@@ -23,10 +23,9 @@ MODIFICATIONS:
        20171201 - Initials - Modification description
        
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 

--- a/stored-procedures/dbo.Check_TableUsage.sql
+++ b/stored-procedures/dbo.Check_TableUsage.sql
@@ -23,6 +23,10 @@ EXAMPLES:
 **************************************************************************************************
 MODIFICATIONS:
     20150107 - 
+**************************************************************************************************
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 

--- a/stored-procedures/dbo.Cleanup_BackupHistory.sql
+++ b/stored-procedures/dbo.Cleanup_BackupHistory.sql
@@ -1,0 +1,115 @@
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE type = 'P' AND object_id = object_id('dbo.Cleanup_BackupHistory'))
+    EXEC ('CREATE PROCEDURE dbo.Cleanup_BackupHistory AS SELECT ''This is a stub''')
+GO
+
+ALTER PROCEDURE dbo.Cleanup_BackupHistory
+    @oldest_date datetime
+AS
+/*************************************************************************************************
+AUTHOR: Erik Darling
+CREATED: 20190329
+    Originally sp_delete_backuphistory_pro
+    This procedure cleans up the msdb backup history, using temp tables to manage what data needs
+    to be deleted. This should improve performance compared to the standard MS-provided
+    sp_delete_backuphistory.
+
+PARAMETERS
+* @oldest_date - datetime - Oldest date/time to retain backup history for
+**************************************************************************************************
+MODIFICATIONS:
+    YYYYMMDD - AM2 - Description
+
+**************************************************************************************************
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
+*************************************************************************************************/
+ BEGIN
+   SET NOCOUNT ON
+
+   CREATE TABLE #backup_set_id      (backup_set_id INT PRIMARY KEY CLUSTERED)
+   CREATE TABLE #media_set_id       (media_set_id INT PRIMARY KEY CLUSTERED)
+   CREATE TABLE #restore_history_id (restore_history_id INT PRIMARY KEY CLUSTERED)
+
+   INSERT INTO #backup_set_id WITH (TABLOCKX) (backup_set_id)
+   SELECT DISTINCT backup_set_id
+   FROM msdb.dbo.backupset
+   WHERE backup_finish_date < @oldest_date
+
+   INSERT INTO #media_set_id WITH (TABLOCKX) (media_set_id)
+   SELECT DISTINCT media_set_id
+   FROM msdb.dbo.backupset
+   WHERE backup_finish_date < @oldest_date
+
+   INSERT INTO #restore_history_id WITH (TABLOCKX) (restore_history_id)
+   SELECT DISTINCT restore_history_id
+   FROM msdb.dbo.restorehistory
+   WHERE backup_set_id IN (SELECT backup_set_id
+                           FROM   #backup_set_id)
+
+   BEGIN TRANSACTION
+
+   DELETE FROM msdb.dbo.backupfile
+   WHERE backup_set_id IN (SELECT backup_set_id
+                           FROM   #backup_set_id)
+   IF (@@error > 0)
+     GOTO Quit
+
+   DELETE FROM msdb.dbo.backupfilegroup
+   WHERE backup_set_id IN (SELECT backup_set_id
+                           FROM   #backup_set_id)
+   IF (@@error > 0)
+     GOTO Quit
+
+   DELETE FROM msdb.dbo.restorefile
+   WHERE restore_history_id IN (SELECT restore_history_id
+                                FROM   #restore_history_id)
+   IF (@@error > 0)
+     GOTO Quit
+
+   DELETE FROM msdb.dbo.restorefilegroup
+   WHERE restore_history_id IN (SELECT restore_history_id
+                                FROM   #restore_history_id)
+   IF (@@error > 0)
+     GOTO Quit
+
+   DELETE FROM msdb.dbo.restorehistory
+   WHERE restore_history_id IN (SELECT restore_history_id
+                                FROM   #restore_history_id)
+   IF (@@error > 0)
+     GOTO Quit
+
+   DELETE FROM msdb.dbo.backupset
+   WHERE backup_set_id IN (SELECT backup_set_id
+                           FROM   #backup_set_id)
+   IF (@@error > 0)
+     GOTO Quit
+
+   DELETE msdb.dbo.backupmediafamily
+   FROM msdb.dbo.backupmediafamily bmf
+   WHERE bmf.media_set_id IN (SELECT media_set_id
+                              FROM   #media_set_id)
+     AND ((SELECT COUNT(*)
+           FROM msdb.dbo.backupset
+           WHERE media_set_id = bmf.media_set_id) = 0)
+   IF (@@error > 0)
+     GOTO Quit
+
+   DELETE msdb.dbo.backupmediaset
+   FROM msdb.dbo.backupmediaset bms
+   WHERE bms.media_set_id IN (SELECT media_set_id
+                              FROM   #media_set_id)
+     AND ((SELECT COUNT(*)
+           FROM msdb.dbo.backupset
+           WHERE media_set_id = bms.media_set_id) = 0)
+   IF (@@error > 0)
+     GOTO Quit
+
+   COMMIT TRANSACTION
+   RETURN
+
+ Quit:
+   ROLLBACK TRANSACTION
+
+ END
+ GO

--- a/stored-procedures/dbo.Cleanup_CommandLog.sql
+++ b/stored-procedures/dbo.Cleanup_CommandLog.sql
@@ -27,10 +27,9 @@ PARAMETERS
 MODIFICATIONS:
     YYYYMMDD - 
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 

--- a/stored-procedures/dbo.Cleanup_Msdb.sql
+++ b/stored-procedures/dbo.Cleanup_Msdb.sql
@@ -21,10 +21,9 @@ PARAMETERS
 MODIFICATIONS:
     YYYYMMDD - 
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 

--- a/stored-procedures/dbo.Cleanup_TableByID.sql
+++ b/stored-procedures/dbo.Cleanup_TableByID.sql
@@ -28,6 +28,8 @@ CREATED: 20171012
        @ChunkSize controls how the max size of each delete operation.
        @LoopWaitTime introduces a wait between each delete to throttle activity between log backups
 
+    KNOWN LIMITATION: If you reseed the identity column back to 0, you're going to delete all
+        your data. All of it. Don't do that.
 
 PARAMETERS
 * @DbName         - Name of the database containing the table
@@ -43,10 +45,9 @@ PARAMETERS
 MODIFICATIONS:
     YYYYMMDD - 
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 

--- a/stored-procedures/dbo.Repl_AddAllTables.sql
+++ b/stored-procedures/dbo.Repl_AddAllTables.sql
@@ -22,10 +22,9 @@ PARAMETERS
 MODIFICATIONS:
     YYYYMMDDD - Initials - Description of changes
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 

--- a/stored-procedures/dbo.Repl_AddArticle.sql
+++ b/stored-procedures/dbo.Repl_AddArticle.sql
@@ -21,10 +21,9 @@ PARAMETERS
 MODIFICATIONS:
     YYYYMMDDD - Initials - Description of changes
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON
 ---------------------

--- a/stored-procedures/dbo.Repl_CreatePublication.sql
+++ b/stored-procedures/dbo.Repl_CreatePublication.sql
@@ -19,10 +19,9 @@ PARAMETERS
 MODIFICATIONS:
     YYYYMMDDD - Initials - Description of changes
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 ---------------------

--- a/stored-procedures/dbo.Repl_CreateSubscription.sql
+++ b/stored-procedures/dbo.Repl_CreateSubscription.sql
@@ -21,10 +21,9 @@ PARAMETERS
 MODIFICATIONS:
     YYYYMMDDD - Initials - Description of changes
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 ---------------------

--- a/stored-procedures/dbo.Views_RecompileAll.sql
+++ b/stored-procedures/dbo.Views_RecompileAll.sql
@@ -26,10 +26,9 @@ EXAMPLES:
 MODIFICATIONS:
     YYYYMMDD - 
 **************************************************************************************************
-    This code is free to download and use for personal, educational, and internal 
-    corporate purposes, provided that this header is preserved. Redistribution or sale, 
-    in whole or in part, is prohibited without the author's express written consent.
-    ©2014-2017 ● Andy Mallon ● am2.co
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
 *************************************************************************************************/
 SET NOCOUNT ON;
 

--- a/stored-procedures/dbo.sp_Get_BaseTableList.sql
+++ b/stored-procedures/dbo.sp_Get_BaseTableList.sql
@@ -1,0 +1,147 @@
+USE master
+GO
+--We don't want to drop/create this guy once we mark it as system
+--Once a developer starts using this in production, will cause problems when it disappears
+--Instead: if it doesn't exist, create a stub & grant permissions, then alter the sproc to use the correct code.
+IF OBJECT_ID('sp_get_basetable_list', 'P') IS  NULL
+BEGIN
+	--do this in dynamic SQL so CREATE PROCEDURE can be nested in this IF block
+	EXEC ('CREATE PROCEDURE dbo.sp_get_basetable_list AS SELECT 1')
+	--mark it as a system object
+	EXEC sp_MS_marksystemobject sp_get_basetable_list
+	--grant permission to the whole world
+	GRANT EXECUTE ON sp_get_basetable_list to PUBLIC
+END
+GO
+
+--Now do an alter
+ALTER PROCEDURE dbo.sp_get_basetable_list
+@object_name varchar(776) = NULL,
+@debug bit = 0
+AS
+/*************************************************************************************************
+AUTHOR: Andy Mallon
+CREATED: 20140228
+       This procedure can be called two ways:
+	   1) by passing a view/synonym/table name to the @object_name parameter
+	   2) by creating & populating #tables (matching schema at start of sproc) then calling the 
+	      sproc with that table populated.
+
+	   If option 1 is used to call the sproc, the table list will be returned in the form
+	   of a result set.
+	   If option 2 is used to call the sproc, then #tables will be populated with the physical 
+	   tables.
+	   
+	   For the object(s) passed to this sproc, look up the physical tables behind it.
+	   * If a synonym is passed, return the base table of that synonym
+	   * If a view is passed, return ALL the base tables of that view
+	   * If a table is passed, return the table itself
+
+	   Lookup is recursive and only ends when #tables contains only tables.
+
+PARAMETERS
+* @object_name - Optional - accept three-part object name (Database.Schema.Table)
+		- If not provided, #tables should exist & be populated, otherwise, raiserror
+**************************************************************************************************
+MODIFICATIONS:
+       YYYYMMDDD - Initials - Description of changes
+**************************************************************************************************
+    This code is licensed under the GNU GPL, as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2019 ● Andy Mallon ● am2.co
+*************************************************************************************************/
+
+SET NOCOUNT ON
+	--If #tables doesn't exist, create it, and populate it from the input param
+	
+	IF (object_id('tempdb..#tables') IS NULL)
+	BEGIN
+		IF @object_name IS NULL
+			RAISERROR ('No table(s) provided.',16,1)
+		CREATE TABLE #tables (DbName sysname, SchemaName sysname, TableName sysname, ObjType char(2) CONSTRAINT pk_tables PRIMARY KEY (DbName, SchemaName, TableName))
+		INSERT INTO #tables (DbName, SchemaName, TableName)
+		SELECT COALESCE(parsename(@object_name,3),db_name()),
+			COALESCE(parsename(@object_name,2),schema_name()),
+			parsename(@object_name,1)
+	END
+
+
+	DECLARE @sql nvarchar(2070)
+	DECLARE @DbName varchar(256)
+	DECLARE @SchemaName varchar(256)
+	DECLARE @TableName varchar(256)
+	DECLARE @ObjType char(2)
+	
+	WHILE EXISTS(SELECT 1 FROM #tables WHERE COALESCE(ObjType,'x') <> 'U')
+	BEGIN
+		DECLARE db_cur CURSOR FOR
+			SELECT DISTINCT DbName FROM #tables
+
+		OPEN db_cur
+		FETCH NEXT FROM db_cur INTO @DbName
+
+		WHILE @@FETCH_STATUS = 0
+		BEGIN
+			-- Get the object types for everything in this DB
+			SET @sql = N'UPDATE t SET ObjType = o.type FROM #tables t JOIN ' + @DbName + '.sys.objects o ON o.schema_id = schema_id(t.SchemaName) AND o.name = t.TableName WHERE t.DbName = ''' + @DbName + ''''
+			IF @debug = 1
+				PRINT @sql
+			EXEC (@sql)
+
+			IF EXISTS (SELECT 1 FROM #tables WHERE DbName = @DbName AND ObjType IS NULL)
+			BEGIN
+				PRINT 'Unable to determine object type for one or more objects.'
+				DELETE FROM #tables WHERE DbName = @DbName AND ObjType IS NULL
+			END
+
+			DECLARE tab_cur CURSOR FOR
+				SELECT SchemaName, TableName, ObjType
+				FROM #tables
+				WHERE DbName = @DbName
+
+			OPEN tab_cur
+			FETCH NEXT FROM tab_cur INTO @SchemaName, @TableName, @ObjType
+			WHILE @@FETCH_STATUS = 0
+			BEGIN
+				IF (@ObjType ='SN') 
+				BEGIN
+					--Its not a table. Delete the current row & replace with object(s) it references
+					DELETE #tables WHERE DbName = @DbName AND SchemaName = @SchemaName AND TableName = @TableName
+					SET @sql = N'INSERT INTO #tables (DbName, SchemaName, TableName) SELECT COALESCE(PARSENAME(base_object_name,3),db_name()), '
+							+ 'COALESCE(PARSENAME(base_object_name,2),schema_name()), PARSENAME(base_object_name,1)  FROM ' + @DbName 
+								+ '.sys.synonyms WHERE name = ''' + @TableName + ''' AND schema_id = schema_id(''' + @SchemaName + ''')'
+					IF @debug = 1
+						PRINT @sql
+					EXEC (@sql)
+				END 
+				
+				ELSE IF (@ObjType <> 'U')
+				BEGIN
+					--Its not a table. Delete the current row & replace with object(s) it references
+					DELETE #tables WHERE DbName = @DbName AND SchemaName = @SchemaName AND TableName = @TableName
+					SET @sql = N'INSERT INTO #tables (DbName, SchemaName, TableName) SELECT DISTINCT COALESCE(referenced_database_name,''' 
+							+ @DbName + '''), COALESCE(referenced_schema_name,''' + @SchemaName + '''), referenced_entity_name FROM ' + QUOTENAME(@DbName) 
+							+ '.sys.dm_sql_referenced_entities (''' + QUOTENAME(@SchemaName) + '.' + QUOTENAME(@TableName) + ''',''OBJECT'') r '
+							+ 'WHERE NOT EXISTS(SELECT 1 FROM #tables t WHERE t.DbName = COALESCE(r.referenced_database_name,''' + @DbName + ''') AND '
+							+ 't.SchemaName = COALESCE(r.referenced_schema_name,''' + @SchemaName + ''') AND t.TableName = r.referenced_entity_name)'
+					IF @debug = 1
+						PRINT @sql
+					EXEC (@sql)
+				END
+				FETCH NEXT FROM tab_cur INTO @SchemaName, @TableName, @ObjType
+			END
+
+			CLOSE tab_cur
+			DEALLOCATE tab_cur
+			FETCH NEXT FROM db_cur INTO @DbName
+		END
+		CLOSE db_cur
+		DEALLOCATE db_cur
+	END
+
+	IF (@object_name IS NOT NULL)
+		SELECT DbName, SchemaName, TableName FROM #tables
+
+	GO
+
+

--- a/tables/dbo.Monitor_Blocking.sql
+++ b/tables/dbo.Monitor_Blocking.sql
@@ -20,7 +20,7 @@ BEGIN
         SqlText nvarchar(max) NULL,
         InputBuffer nvarchar(4000) NULL,
         SqlStatement nvarchar(max) NULL,
-        CONSTRAINT PK_cfn_Monitor_Blocking PRIMARY KEY CLUSTERED (LogDateTime,LogId )
+        CONSTRAINT PK_Monitor_Blocking PRIMARY KEY CLUSTERED (LogDateTime,LogId )
     ) ON [DATA];
 END
 GO


### PR DESCRIPTION
* slow SQL fix

this allows the numbers table to be created on a slower engine

* Create dbo.Getet_BaseTableList.sql

* Fix module headers to reference correct license terms. Oops.

* Add code from Erik Darling

Adding Erik's sp_delete_backuphistory_pro as Cleanup_BackupHistory

Co-Authored-By: Erik Darling <erikdarlingdata@users.noreply.github.com>

* Update dbo.Check_Blocking.sql

fix typo in comment

* Update dbo.Monitor_Blocking.sql

Fix PK name

* Update dbo.Check_OpenTransactions.sql

Add filter to only include sleeping sessions in results

* Update dbo.Cleanup_TableByID.sql

Add note to comments about reseeding. You might call it a bug, I call it a "known limitation"