### PR TITLE
Add Debug_Print proc and route debug SQL dumps through it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ PARAMETERS
 
 EXAMPLES:
 -- The most common way you'd actually call this:
--- EXEC dbo.Check_StatsDetails @DbName = N'Mobo';
+-- EXEC dbo.Check_StatsDetails @DbName = N'AMtwo';
 
 **************************************************************************************************
 MODIFICATIONS:

--- a/stored-procedures/dbo.Check_FileSize.sql
+++ b/stored-procedures/dbo.Check_FileSize.sql
@@ -8,7 +8,8 @@ ALTER PROCEDURE dbo.Check_FileSize
     @Drive char(1) = NULL,
     @IncludeDataFiles bit = 1,
     @IncludeLogFiles bit = 1,
-    @OrderBy nvarchar(100) = NULL
+    @OrderBy nvarchar(100) = NULL,
+    @Debug bit = 0
 AS
 /*************************************************************************************************
 AUTHOR: Andy Mallon
@@ -23,6 +24,7 @@ PARAMETERS
 * @IncludeLogFiles  - Default 1 (True) - Flag to enable checking of log file sizes. Defaults to true.
 * @OrderBy - Default NULL - The value used in the order by clause of the result set.
                             When NULL or an invalid value passed, ordered by ServerName, DbName, LogicalFileName
+* @Debug  - Default 0 (False) - When 1, PRINT the dynamic SQL before running it.
 
 EXAMPLES:
 * Check File size/usage for internal_tracking database
@@ -122,7 +124,8 @@ IF @Drive IS NOT NULL
 --include order by
 SET @sql = @sql + N' ORDER BY ' + @OrderBy;
 
-PRINT @sql;
+IF @Debug = 1
+    EXEC dbo.Debug_Print @DebugMessage = @sql;
 
 EXEC sys.sp_executesql @sql;
 

--- a/stored-procedures/dbo.Check_LogVLF.sql
+++ b/stored-procedures/dbo.Check_LogVLF.sql
@@ -4,7 +4,8 @@ GO
 
 
 ALTER PROCEDURE dbo.Check_LogVLF
-    @Threshold tinyint = 0
+    @Threshold tinyint = 0,
+    @Debug bit = 0
 AS
 /*************************************************************************************************
 AUTHOR: Andy Mallon
@@ -14,8 +15,9 @@ CREATED: 20141001
     The @Threshold controls what DBs should be included in the result set
        
 PARAMETERS
-* @Threshold - Default 0 - Number of VLFs. Can be used to filter out databases with a small 
+* @Threshold - Default 0 - Number of VLFs. Can be used to filter out databases with a small
                 number of VLFs, in case you don't care about those.
+* @Debug     - Default 0 (False) - When 1, PRINT the per-database DBCC LOGINFO dynamic SQL.
 EXAMPLES:
 
 
@@ -71,7 +73,8 @@ WHILE @@FETCH_STATUS=0
         SET @sql='Insert #LogInfo(fileid, file_size, start_offset, FSeqNo, [status], parity, create_lsn) Exec(''DBCC loginfo ('+QUOTENAME(@dbname)+')'')';
     ELSE 
         SET @sql='Insert #LogInfo(RecoveryUnitID, fileid, file_size, start_offset, FSeqNo, [status], parity, create_lsn) Exec(''DBCC loginfo ('+QUOTENAME(@dbname)+')'')';
-    PRINT @sql;
+    IF @Debug = 1
+        EXEC dbo.Debug_Print @DebugMessage = @sql;
     EXEC sys.sp_executesql @stmt = @sql;
     UPDATE #Results SET vlf=(SELECT COUNT(*) FROM #LogInfo) WHERE dbname=@DbName;
     FETCH Next FROM db_cur INTO @DbName;

--- a/stored-procedures/dbo.Check_QueryStoreRegressedQueries.sql
+++ b/stored-procedures/dbo.Check_QueryStoreRegressedQueries.sql
@@ -113,9 +113,10 @@ BEGIN
     ORDER BY additional_duration_workload DESC  
     OPTION (MERGE JOIN);';
 
-    PRINT @CheckSql;
+    IF @Debug = 1
+        EXEC dbo.Debug_Print @DebugMessage = @CheckSql;
 
-    EXEC DBA.dbo.sp_ineachdb 
+    EXEC DBA.dbo.sp_ineachdb
         @command              = @CheckSQL,
         @print_command        = @Debug,
         @name_pattern         = @DbNamePattern,

--- a/stored-procedures/dbo.Check_StatsDetails.sql
+++ b/stored-procedures/dbo.Check_StatsDetails.sql
@@ -1,14 +1,15 @@
 CREATE OR ALTER PROCEDURE dbo.Check_StatsDetails
     @DbName              sysname,
+    @Mode                varchar(10)   = 'ROLLUP',     -- DETAIL, ROLLUP, or ALL (see header)
     @SchemaName          sysname       = NULL,        -- Filter by schema
     @ObjectName          sysname       = NULL,        -- Filter by table
-    @StatisticName       sysname       = NULL,        -- Filter by statistic/index name
+    @StatisticName       sysname       = NULL,        -- Filter by statistic/index name (DETAIL only)
     @RowCountThreshold   bigint        = 10000000,    -- N rule: >= N rows uses sampled update
     @GiantSamplePercent  tinyint       = 50,          -- Sample percent when table is >= N rows
     @LowSamplePctCutoff  decimal(5,2)  = 5.00,        -- Low sample cutoff for NORECOMPUTE recommendation
     @SkewRatioCutoff     decimal(10,2) = 100.00,      -- Histogram max/avg ratio considered skewed
-    @OnlySuspicious      bit           = 0,           -- 1 = only rows that may need action
-    @IncludeSkewAnalysis bit           = 1,           -- 0 = skip histogram analysis
+    @OnlySuspicious      bit           = 0,           -- 1 = only rows that may need action (DETAIL only)
+    @IncludeSkewAnalysis bit           = 1,           -- 0 = skip histogram analysis (DETAIL only)
     @Debug               bit           = 0            -- 1 = print dynamic SQL and return
 AS
 /*************************************************************************************************
@@ -21,38 +22,55 @@ CREATED: 20260629
     * Low sample percentages => NORECOMPUTE candidate
     * High histogram skew ratio => filtered statistics review candidate
 
+    @Mode controls the output granularity:
+    * DETAIL - One row per statistic, including per-stat sampling and histogram skew.
+    * ROLLUP - One row per table, collapsing the per-stat detail to spot tables where
+               one stat is under-sampled while its siblings are fine (an index-level
+               NORECOMPUTE candidate). This is the default.
+    * ALL    - Returns both result sets (DETAIL first, then ROLLUP).
+
 PARAMETERS
 * @DbName - Target database name.
+* @Mode - Output granularity: DETAIL (per-statistic), ROLLUP (per-table), or ALL (both). Defaults to ROLLUP.
 * @SchemaName - Optional schema filter.
 * @ObjectName - Optional table filter.
-* @StatisticName - Optional statistic/index filter.
+* @StatisticName - Optional statistic/index filter. Only meaningful for DETAIL.
 * @RowCountThreshold - Row count breakpoint for sample policy.
 * @GiantSamplePercent - Sample percentage for tables at or above the breakpoint.
 * @LowSamplePctCutoff - Threshold for low observed sample percentage.
-* @SkewRatioCutoff - Threshold for max-step-to-avg-step histogram ratio.
-* @OnlySuspicious - Return only rows with low sample or non-zero modification counter.
-* @IncludeSkewAnalysis - Include histogram analysis (heavier DMV access).
+* @SkewRatioCutoff - Threshold for max-step-to-avg-step histogram ratio. Only used by DETAIL.
+* @OnlySuspicious - Return only rows with low sample or non-zero modification counter. Only used by DETAIL.
+* @IncludeSkewAnalysis - Include histogram analysis (heavier DMV access). Only used by DETAIL.
 * @Debug - Print assembled dynamic SQL and exit.
 
 EXAMPLES:
--- Whole database:
+-- Whole database, per-table rollup (the default):
 -- EXEC dbo.Check_StatsDetails @DbName = N'Mobo';
 
--- Single table:
+-- Per-statistic detail for the whole database:
+-- EXEC dbo.Check_StatsDetails @DbName = N'Mobo', @Mode = 'DETAIL';
+
+-- Both result sets at once:
+-- EXEC dbo.Check_StatsDetails @DbName = N'Mobo', @Mode = 'ALL';
+
+-- Single table, per-statistic detail:
 -- EXEC dbo.Check_StatsDetails
 --     @DbName = N'Mobo',
+--     @Mode = 'DETAIL',
 --     @SchemaName = N'dbo',
 --     @ObjectName = N'Order';
 
 -- Single statistic and skip skew analysis:
 -- EXEC dbo.Check_StatsDetails
 --     @DbName = N'Mobo',
+--     @Mode = 'DETAIL',
 --     @StatisticName = N'CUIX_OpenOrder',
 --     @IncludeSkewAnalysis = 0;
 
 -- Return only suspicious rows:
 -- EXEC dbo.Check_StatsDetails
 --     @DbName = N'Mobo',
+--     @Mode = 'DETAIL',
 --     @OnlySuspicious = 1;
 
 -- Print generated SQL only:
@@ -62,6 +80,8 @@ EXAMPLES:
 MODIFICATIONS:
     20260629 - AM2 - Normalize formatting/comments to current repository style.
     20260629 - AM2 - Rename procedure to dbo.Check_StatsDetails to match filename.
+    20260629 - AM2 - Add @Mode (DETAIL/ROLLUP/ALL); promote the table-level rollup from an
+                     ad-hoc comment into a real, parameterized result set.
 **************************************************************************************************
     This code is licensed as part of Andy Mallon's DBA Database.
     https://github.com/amtwo/dba-database/blob/master/LICENSE
@@ -69,20 +89,42 @@ MODIFICATIONS:
 *************************************************************************************************/
 BEGIN
     SET NOCOUNT ON;
-    SET XACT_ABORT ON;
 
+    -- Validate the target database exists before we build anything against it.
     IF DB_ID(@DbName) IS NULL
     BEGIN
         RAISERROR('Database %s not found on this instance.', 16, 1, @DbName);
         RETURN;
     END;
 
-    DECLARE @sql nvarchar(max);
+    -- Normalize @Mode so callers don't get tripped up by case or stray whitespace,
+    -- then validate it against the supported set before doing any work.
+    SET @Mode = UPPER(LTRIM(RTRIM(@Mode)));
 
-    -- Stats DMVs are database-scoped, so execute in target database context.
-    SET @sql = N'
-    USE ' + QUOTENAME(@DbName) + N';
+    IF @Mode NOT IN ('DETAIL', 'ROLLUP', 'ALL')
+    BEGIN
+        RAISERROR('@Mode must be one of: DETAIL, ROLLUP, or ALL.', 16, 1);
+        RETURN;
+    END;
 
+    -- @sql is the batch we ultimately execute. We build the DETAIL and ROLLUP
+    -- statements into their own variables, then stitch together whichever ones
+    -- the requested @Mode calls for.
+    DECLARE
+        @sql       nvarchar(max),
+        @detailSql nvarchar(max),
+        @rollupSql nvarchar(max);
+
+    -- Stats DMVs are database-scoped, so the whole batch must run in the target
+    -- database's context. Set it once at the top; every statement we append inherits it.
+    SET @sql = N'USE ' + QUOTENAME(@DbName) + N';' + NCHAR(13) + NCHAR(10);
+
+    -------------------------------------------------------------------------------------------
+    -- DETAIL: one row per statistic.
+    -- TableRows gives us the allocated row count per table (heap or clustered index).
+    -- Skew (optional) summarizes histogram step distribution to flag lopsided stats.
+    -------------------------------------------------------------------------------------------
+    SET @detailSql = N'
     WITH TableRows AS (
         SELECT
             ps.object_id,
@@ -118,6 +160,7 @@ BEGIN
         IsAutoCreated  = s.auto_created,
         IsUserCreated  = s.user_created,
         IsFiltered     = CASE WHEN s.has_filter = 1 THEN 1 ELSE 0 END,
+        -- Skew ratio is max histogram step rows over the average. Only computed when asked.
         SkewRatio      = CASE
                             WHEN @IncludeSkew = 1
                                 THEN TRY_CONVERT(decimal(19,2), sk.MaxStepRows / sk.AvgStepRows)
@@ -129,11 +172,13 @@ BEGIN
                                 THEN 1
                             ELSE 0
                          END,
+        -- Recommended sample policy: big tables get a sample, everything else FULLSCAN.
         RecSamplePolicy = CASE
                             WHEN tr.RowCount_Alloc >= @N
                                 THEN CONCAT(N''SAMPLE '', @GiantPct, N'' PERCENT'')
                             ELSE N''FULLSCAN''
                           END,
+        -- Plain-language recommendation, evaluated most-severe-first.
         RecAction = CASE
                         WHEN @IncludeSkew = 1
                              AND (sk.MaxStepRows / sk.AvgStepRows) > @SkewCutoff
@@ -146,6 +191,7 @@ BEGIN
                             THEN N''NORECOMPUTE candidate (low sample, autostats on)''
                         ELSE N''OK / leave as BAU''
                     END,
+        -- Copy/paste remediation statement for this specific stat.
         FixSql = CONCAT(
                     N''UPDATE STATISTICS '', QUOTENAME(sch.name), N''.'', QUOTENAME(o.name),
                     N'' ('', QUOTENAME(s.name), N'') WITH '',
@@ -179,27 +225,88 @@ BEGIN
         tr.RowCount_Alloc DESC,
         CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0)) ASC;';
 
+    -------------------------------------------------------------------------------------------
+    -- ROLLUP: one row per table.
+    -- Collapses the per-stat detail to surface tables where one stat is badly under-sampled
+    -- while its siblings look fine -- the classic "fix this one index's stats" scenario.
+    -- @StatisticName / @OnlySuspicious / skew don't apply at table grain, so they're ignored here.
+    -------------------------------------------------------------------------------------------
+    SET @rollupSql = N'
+    WITH TableRows AS (
+        SELECT
+            ps.object_id,
+            RowCount_Alloc = SUM(CASE WHEN ps.index_id IN (0, 1) THEN ps.row_count ELSE 0 END)
+        FROM sys.dm_db_partition_stats AS ps
+        GROUP BY ps.object_id
+    ),
+    StatDetail AS (
+        SELECT
+            o.object_id,
+            SchemaName    = sch.name,
+            TableName     = o.name,
+            tr.RowCount_Alloc,
+            -- Spread of sample percentages across this table''s stats.
+            MinSamplePct  = MIN(CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0))),
+            MaxSamplePct  = MAX(CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0))),
+            StatCount     = COUNT(*),
+            NoRecompute   = SUM(CONVERT(int, s.no_recompute)),
+            MaxModCounter = MAX(sp.modification_counter)
+        FROM sys.stats AS s
+        JOIN sys.objects AS o
+            ON o.object_id = s.object_id
+        JOIN sys.schemas AS sch
+            ON sch.schema_id = o.schema_id
+        CROSS APPLY sys.dm_db_stats_properties(s.object_id, s.stats_id) AS sp
+        LEFT JOIN TableRows AS tr
+            ON tr.object_id = s.object_id
+        WHERE o.is_ms_shipped = 0
+          AND (@SchemaName IS NULL OR sch.name = @SchemaName)
+          AND (@ObjectName IS NULL OR o.name = @ObjectName)
+        GROUP BY o.object_id, sch.name, o.name, tr.RowCount_Alloc
+    )
+    SELECT
+        SchemaName,
+        TableName,
+        RowCount_Alloc,
+        MinSamplePct,
+        MaxSamplePct,
+        StatCount,
+        NoRecompute,
+        MaxModCounter,
+        RecSamplePolicy = CASE
+                            WHEN RowCount_Alloc >= @N
+                                THEN CONCAT(N''SAMPLE '', @GiantPct, N'' PERCENT'')
+                            ELSE N''FULLSCAN''
+                          END,
+        -- Flag tables with a wide sampling spread: at least one stat well under the cutoff
+        -- while another is sampled comfortably (>= 20%). That mix points at an index-level fix.
+        IndexLevelExceptionFlag = CASE
+                                    WHEN MinSamplePct < @LowCutoff
+                                         AND MaxSamplePct >= 20.00
+                                        THEN N''Mixed: one stat under-sampled while others fine -> consider INDEX-level NORECOMPUTE''
+                                    ELSE N''''
+                                  END
+    FROM StatDetail
+    ORDER BY RowCount_Alloc DESC, MinSamplePct ASC;';
+
+    -- Stitch the batch together. DETAIL and ROLLUP both contribute under ALL; each statement
+    -- is self-terminated with a semicolon, so they run back-to-back as two result sets.
+    IF @Mode IN ('DETAIL', 'ALL')
+        SET @sql += @detailSql;
+
+    IF @Mode IN ('ROLLUP', 'ALL')
+        SET @sql += @rollupSql;
+
+    -- Debug: dump the assembled SQL and bail. @sql routinely blows past PRINT's 4000-char limit,
+    -- so hand it to dbo.Debug_Print, which chunks it on whitespace boundaries for readability.
     IF @Debug = 1
     BEGIN
-        DECLARE
-            @pos int = 1,
-            @len int = LEN(@sql),
-            @chunk int;
-
-        WHILE @pos <= @len
-        BEGIN
-            SET @chunk = CHARINDEX(CHAR(10), @sql, @pos + 3500) - @pos;
-
-            IF @chunk <= 0
-                SET @chunk = 4000;
-
-            PRINT SUBSTRING(@sql, @pos, @chunk);
-            SET @pos = @pos + @chunk;
-        END;
-
+        EXEC dbo.Debug_Print @DebugMessage = @sql;
         RETURN;
     END;
 
+    -- One unified parameter list serves both statements. ROLLUP simply doesn't reference the
+    -- DETAIL-only parameters; passing them anyway is harmless and keeps the call site simple.
     EXEC sys.sp_executesql
         @sql,
         N'@N bigint,
@@ -222,55 +329,3 @@ BEGIN
         @StatisticName  = @StatisticName;
 END;
 GO
-
-/*
-    TABLE-LEVEL ROLLUP (ad-hoc companion query):
-    Collapses per-stat rows to one row per table to identify potential
-    index-level exception scenarios.
-
-    USE Mobo;
-
-    WITH TableRows AS (
-        SELECT
-            ps.object_id,
-            RowCount_Alloc = SUM(CASE WHEN ps.index_id IN (0, 1) THEN ps.row_count ELSE 0 END)
-        FROM sys.dm_db_partition_stats AS ps
-        GROUP BY ps.object_id
-    ),
-    StatDetail AS (
-        SELECT
-            o.object_id,
-            SchemaName    = sch.name,
-            TableName     = o.name,
-            tr.RowCount_Alloc,
-            MinSamplePct  = MIN(CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0))),
-            MaxSamplePct  = MAX(CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0))),
-            StatCount     = COUNT(*),
-            NoRecompute   = SUM(CONVERT(int, s.no_recompute)),
-            MaxModCounter = MAX(sp.modification_counter)
-        FROM sys.stats AS s
-        JOIN sys.objects AS o
-            ON o.object_id = s.object_id
-        JOIN sys.schemas AS sch
-            ON sch.schema_id = o.schema_id
-        CROSS APPLY sys.dm_db_stats_properties(s.object_id, s.stats_id) AS sp
-        LEFT JOIN TableRows AS tr
-            ON tr.object_id = s.object_id
-        WHERE o.is_ms_shipped = 0
-        GROUP BY o.object_id, sch.name, o.name, tr.RowCount_Alloc
-    )
-    SELECT
-        *,
-        RecSamplePolicy = CASE
-                            WHEN RowCount_Alloc >= 10000000 THEN N''SAMPLE 50 PERCENT''
-                            ELSE N''FULLSCAN''
-                          END,
-        IndexLevelExceptionFlag = CASE
-                                    WHEN MinSamplePct < 5.00
-                                         AND MaxSamplePct >= 20.00
-                                        THEN N''Mixed: one stat under-sampled while others fine -> consider INDEX-level NORECOMPUTE''
-                                    ELSE N''''
-                                  END
-    FROM StatDetail
-    ORDER BY RowCount_Alloc DESC, MinSamplePct ASC;
-*/

--- a/stored-procedures/dbo.Check_StatsDetails.sql
+++ b/stored-procedures/dbo.Check_StatsDetails.sql
@@ -1,0 +1,276 @@
+CREATE OR ALTER PROCEDURE dbo.Check_StatsDetails
+    @DbName              sysname,
+    @SchemaName          sysname       = NULL,        -- Filter by schema
+    @ObjectName          sysname       = NULL,        -- Filter by table
+    @StatisticName       sysname       = NULL,        -- Filter by statistic/index name
+    @RowCountThreshold   bigint        = 10000000,    -- N rule: >= N rows uses sampled update
+    @GiantSamplePercent  tinyint       = 50,          -- Sample percent when table is >= N rows
+    @LowSamplePctCutoff  decimal(5,2)  = 5.00,        -- Low sample cutoff for NORECOMPUTE recommendation
+    @SkewRatioCutoff     decimal(10,2) = 100.00,      -- Histogram max/avg ratio considered skewed
+    @OnlySuspicious      bit           = 0,           -- 1 = only rows that may need action
+    @IncludeSkewAnalysis bit           = 1,           -- 0 = skip histogram analysis
+    @Debug               bit           = 0            -- 1 = print dynamic SQL and return
+AS
+/*************************************************************************************************
+AUTHOR: Andy Mallon
+CREATED: 20260629
+    Read-only statistics recommendation report for a target database.
+    Applies the DB-747 policy model:
+    * Tables below @RowCountThreshold => FULLSCAN recommendation
+    * Tables at/above @RowCountThreshold => SAMPLE @GiantSamplePercent recommendation
+    * Low sample percentages => NORECOMPUTE candidate
+    * High histogram skew ratio => filtered statistics review candidate
+
+PARAMETERS
+* @DbName - Target database name.
+* @SchemaName - Optional schema filter.
+* @ObjectName - Optional table filter.
+* @StatisticName - Optional statistic/index filter.
+* @RowCountThreshold - Row count breakpoint for sample policy.
+* @GiantSamplePercent - Sample percentage for tables at or above the breakpoint.
+* @LowSamplePctCutoff - Threshold for low observed sample percentage.
+* @SkewRatioCutoff - Threshold for max-step-to-avg-step histogram ratio.
+* @OnlySuspicious - Return only rows with low sample or non-zero modification counter.
+* @IncludeSkewAnalysis - Include histogram analysis (heavier DMV access).
+* @Debug - Print assembled dynamic SQL and exit.
+
+EXAMPLES:
+-- Whole database:
+-- EXEC dbo.Check_StatsDetails @DbName = N'Mobo';
+
+-- Single table:
+-- EXEC dbo.Check_StatsDetails
+--     @DbName = N'Mobo',
+--     @SchemaName = N'dbo',
+--     @ObjectName = N'Order';
+
+-- Single statistic and skip skew analysis:
+-- EXEC dbo.Check_StatsDetails
+--     @DbName = N'Mobo',
+--     @StatisticName = N'CUIX_OpenOrder',
+--     @IncludeSkewAnalysis = 0;
+
+-- Return only suspicious rows:
+-- EXEC dbo.Check_StatsDetails
+--     @DbName = N'Mobo',
+--     @OnlySuspicious = 1;
+
+-- Print generated SQL only:
+-- EXEC dbo.Check_StatsDetails @DbName = N'Mobo', @Debug = 1;
+
+**************************************************************************************************
+MODIFICATIONS:
+    20260629 - AM2 - Normalize formatting/comments to current repository style.
+    20260629 - AM2 - Rename procedure to dbo.Check_StatsDetails to match filename.
+**************************************************************************************************
+    This code is licensed as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2026 ● Andy Mallon ● am2.co
+*************************************************************************************************/
+BEGIN
+    SET NOCOUNT ON;
+    SET XACT_ABORT ON;
+
+    IF DB_ID(@DbName) IS NULL
+    BEGIN
+        RAISERROR('Database %s not found on this instance.', 16, 1, @DbName);
+        RETURN;
+    END;
+
+    DECLARE @sql nvarchar(max);
+
+    -- Stats DMVs are database-scoped, so execute in target database context.
+    SET @sql = N'
+    USE ' + QUOTENAME(@DbName) + N';
+
+    WITH TableRows AS (
+        SELECT
+            ps.object_id,
+            RowCount_Alloc = SUM(CASE WHEN ps.index_id IN (0, 1) THEN ps.row_count ELSE 0 END)
+        FROM sys.dm_db_partition_stats AS ps
+        GROUP BY ps.object_id
+    ),
+    Skew AS (
+        SELECT
+            s.object_id,
+            s.stats_id,
+            StepCount   = COUNT(*),
+            MaxStepRows = MAX(h.equal_rows + h.range_rows),
+            AvgStepRows = NULLIF(AVG(h.equal_rows + h.range_rows), 0)
+        FROM sys.stats AS s
+        CROSS APPLY sys.dm_db_stats_histogram(s.object_id, s.stats_id) AS h
+        WHERE @IncludeSkew = 1
+        GROUP BY s.object_id, s.stats_id
+    )
+    SELECT
+        DatabaseName   = DB_NAME(),
+        SchemaName     = sch.name,
+        TableName      = o.name,
+        StatName       = s.name,
+        RowCount_Alloc = tr.RowCount_Alloc,
+        Rows_Stat      = sp.[rows],
+        RowsSampled    = sp.rows_sampled,
+        SamplePercent  = CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0)),
+        ModCounter     = sp.modification_counter,
+        ModPct         = TRY_CONVERT(decimal(19,2), 100.0 * sp.modification_counter / NULLIF(sp.[rows], 0)),
+        LastUpdated    = sp.last_updated,
+        IsNoRecompute  = s.no_recompute,
+        IsAutoCreated  = s.auto_created,
+        IsUserCreated  = s.user_created,
+        IsFiltered     = CASE WHEN s.has_filter = 1 THEN 1 ELSE 0 END,
+        SkewRatio      = CASE
+                            WHEN @IncludeSkew = 1
+                                THEN TRY_CONVERT(decimal(19,2), sk.MaxStepRows / sk.AvgStepRows)
+                            ELSE NULL
+                         END,
+        IsSkewed       = CASE
+                            WHEN @IncludeSkew = 1
+                                AND (sk.MaxStepRows / sk.AvgStepRows) > @SkewCutoff
+                                THEN 1
+                            ELSE 0
+                         END,
+        RecSamplePolicy = CASE
+                            WHEN tr.RowCount_Alloc >= @N
+                                THEN CONCAT(N''SAMPLE '', @GiantPct, N'' PERCENT'')
+                            ELSE N''FULLSCAN''
+                          END,
+        RecAction = CASE
+                        WHEN @IncludeSkew = 1
+                             AND (sk.MaxStepRows / sk.AvgStepRows) > @SkewCutoff
+                            THEN N''REVIEW: skewed -> consider FILTERED STATISTICS on hot range''
+                        WHEN s.auto_created = 1
+                             AND CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0)) < @LowCutoff
+                            THEN N''NORECOMPUTE candidate (auto-stat under-sampling)''
+                        WHEN s.no_recompute = 0
+                             AND CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0)) < @LowCutoff
+                            THEN N''NORECOMPUTE candidate (low sample, autostats on)''
+                        ELSE N''OK / leave as BAU''
+                    END,
+        FixSql = CONCAT(
+                    N''UPDATE STATISTICS '', QUOTENAME(sch.name), N''.'', QUOTENAME(o.name),
+                    N'' ('', QUOTENAME(s.name), N'') WITH '',
+                    CASE
+                        WHEN tr.RowCount_Alloc >= @N
+                            THEN CONCAT(N''SAMPLE '', @GiantPct, N'' PERCENT'')
+                        ELSE N''FULLSCAN''
+                    END,
+                    N'', NORECOMPUTE;'')
+    FROM sys.stats AS s
+    JOIN sys.objects AS o
+        ON o.object_id = s.object_id
+    JOIN sys.schemas AS sch
+        ON sch.schema_id = o.schema_id
+    CROSS APPLY sys.dm_db_stats_properties(s.object_id, s.stats_id) AS sp
+    LEFT JOIN TableRows AS tr
+        ON tr.object_id = s.object_id
+    LEFT JOIN Skew AS sk
+        ON sk.object_id = s.object_id
+        AND sk.stats_id = s.stats_id
+    WHERE o.is_ms_shipped = 0
+      AND (@SchemaName IS NULL OR sch.name = @SchemaName)
+      AND (@ObjectName IS NULL OR o.name = @ObjectName)
+      AND (@StatisticName IS NULL OR s.name = @StatisticName)
+      AND (
+            @OnlySuspicious = 0
+            OR CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0)) < @LowCutoff
+            OR sp.modification_counter > 0
+      )
+    ORDER BY
+        tr.RowCount_Alloc DESC,
+        CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0)) ASC;';
+
+    IF @Debug = 1
+    BEGIN
+        DECLARE
+            @pos int = 1,
+            @len int = LEN(@sql),
+            @chunk int;
+
+        WHILE @pos <= @len
+        BEGIN
+            SET @chunk = CHARINDEX(CHAR(10), @sql, @pos + 3500) - @pos;
+
+            IF @chunk <= 0
+                SET @chunk = 4000;
+
+            PRINT SUBSTRING(@sql, @pos, @chunk);
+            SET @pos = @pos + @chunk;
+        END;
+
+        RETURN;
+    END;
+
+    EXEC sys.sp_executesql
+        @sql,
+        N'@N bigint,
+          @GiantPct tinyint,
+          @LowCutoff decimal(5,2),
+          @SkewCutoff decimal(10,2),
+          @OnlySuspicious bit,
+          @IncludeSkew bit,
+          @SchemaName sysname,
+          @ObjectName sysname,
+          @StatisticName sysname',
+        @N              = @RowCountThreshold,
+        @GiantPct       = @GiantSamplePercent,
+        @LowCutoff      = @LowSamplePctCutoff,
+        @SkewCutoff     = @SkewRatioCutoff,
+        @OnlySuspicious = @OnlySuspicious,
+        @IncludeSkew    = @IncludeSkewAnalysis,
+        @SchemaName     = @SchemaName,
+        @ObjectName     = @ObjectName,
+        @StatisticName  = @StatisticName;
+END;
+GO
+
+/*
+    TABLE-LEVEL ROLLUP (ad-hoc companion query):
+    Collapses per-stat rows to one row per table to identify potential
+    index-level exception scenarios.
+
+    USE Mobo;
+
+    WITH TableRows AS (
+        SELECT
+            ps.object_id,
+            RowCount_Alloc = SUM(CASE WHEN ps.index_id IN (0, 1) THEN ps.row_count ELSE 0 END)
+        FROM sys.dm_db_partition_stats AS ps
+        GROUP BY ps.object_id
+    ),
+    StatDetail AS (
+        SELECT
+            o.object_id,
+            SchemaName    = sch.name,
+            TableName     = o.name,
+            tr.RowCount_Alloc,
+            MinSamplePct  = MIN(CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0))),
+            MaxSamplePct  = MAX(CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0))),
+            StatCount     = COUNT(*),
+            NoRecompute   = SUM(CONVERT(int, s.no_recompute)),
+            MaxModCounter = MAX(sp.modification_counter)
+        FROM sys.stats AS s
+        JOIN sys.objects AS o
+            ON o.object_id = s.object_id
+        JOIN sys.schemas AS sch
+            ON sch.schema_id = o.schema_id
+        CROSS APPLY sys.dm_db_stats_properties(s.object_id, s.stats_id) AS sp
+        LEFT JOIN TableRows AS tr
+            ON tr.object_id = s.object_id
+        WHERE o.is_ms_shipped = 0
+        GROUP BY o.object_id, sch.name, o.name, tr.RowCount_Alloc
+    )
+    SELECT
+        *,
+        RecSamplePolicy = CASE
+                            WHEN RowCount_Alloc >= 10000000 THEN N''SAMPLE 50 PERCENT''
+                            ELSE N''FULLSCAN''
+                          END,
+        IndexLevelExceptionFlag = CASE
+                                    WHEN MinSamplePct < 5.00
+                                         AND MaxSamplePct >= 20.00
+                                        THEN N''Mixed: one stat under-sampled while others fine -> consider INDEX-level NORECOMPUTE''
+                                    ELSE N''''
+                                  END
+    FROM StatDetail
+    ORDER BY RowCount_Alloc DESC, MinSamplePct ASC;
+*/

--- a/stored-procedures/dbo.Check_StatsDetails.sql
+++ b/stored-procedures/dbo.Check_StatsDetails.sql
@@ -181,36 +181,7 @@ BEGIN
                                 AND (sk.MaxStepRows / sk.AvgStepRows) > @SkewCutoff
                                 THEN 1
                             ELSE 0
-                         END,
-        -- Recommended sample policy: big tables get a sample, everything else FULLSCAN.
-        RecSamplePolicy = CASE
-                            WHEN tr.RowCount_Alloc >= @N
-                                THEN CONCAT(N''SAMPLE '', @GiantPct, N'' PERCENT'')
-                            ELSE N''FULLSCAN''
-                          END,
-        -- Plain-language recommendation, evaluated most-severe-first.
-        RecAction = CASE
-                        WHEN @IncludeSkew = 1
-                             AND (sk.MaxStepRows / sk.AvgStepRows) > @SkewCutoff
-                            THEN N''REVIEW: skewed -> consider FILTERED STATISTICS on hot range''
-                        WHEN s.auto_created = 1
-                             AND CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0)) < @LowCutoff
-                            THEN N''NORECOMPUTE candidate (auto-stat under-sampling)''
-                        WHEN s.no_recompute = 0
-                             AND CONVERT(decimal(5,2), 100.0 * sp.rows_sampled / NULLIF(sp.[rows], 0)) < @LowCutoff
-                            THEN N''NORECOMPUTE candidate (low sample, autostats on)''
-                        ELSE N''OK / leave as BAU''
-                    END,
-        -- Copy/paste remediation statement for this specific stat.
-        FixSql = CONCAT(
-                    N''UPDATE STATISTICS '', QUOTENAME(sch.name), N''.'', QUOTENAME(o.name),
-                    N'' ('', QUOTENAME(s.name), N'') WITH '',
-                    CASE
-                        WHEN tr.RowCount_Alloc >= @N
-                            THEN CONCAT(N''SAMPLE '', @GiantPct, N'' PERCENT'')
-                        ELSE N''FULLSCAN''
-                    END,
-                    N'', NORECOMPUTE;'')
+                         END
     FROM sys.stats AS s
     JOIN sys.objects AS o
         ON o.object_id = s.object_id
@@ -283,17 +254,12 @@ BEGIN
         StatCount,
         NoRecompute,
         MaxModCounter,
-        RecSamplePolicy = CASE
-                            WHEN RowCount_Alloc >= @N
-                                THEN CONCAT(N''SAMPLE '', @GiantPct, N'' PERCENT'')
-                            ELSE N''FULLSCAN''
-                          END,
         -- Flag tables with a wide sampling spread: at least one stat well under the cutoff
         -- while another is sampled comfortably (>= 20%). That mix points at an index-level fix.
         IndexLevelExceptionFlag = CASE
                                     WHEN MinSamplePct < @LowCutoff
                                          AND MaxSamplePct >= 20.00
-                                        THEN N''Mixed: one stat under-sampled while others fine -> consider INDEX-level NORECOMPUTE''
+                                        THEN N''Mixed: one stat under-sampled while others fine -> investigate DETAIL-level stats''
                                     ELSE N''''
                                   END
     FROM StatDetail

--- a/stored-procedures/dbo.Check_StatsDetails.sql
+++ b/stored-procedures/dbo.Check_StatsDetails.sql
@@ -4,9 +4,7 @@ CREATE OR ALTER PROCEDURE dbo.Check_StatsDetails
     @SchemaName          sysname       = NULL,        -- Filter by schema
     @ObjectName          sysname       = NULL,        -- Filter by table
     @StatisticName       sysname       = NULL,        -- Filter by statistic/index name (DETAIL only)
-    @RowCountThreshold   bigint        = 10000000,    -- N rule: >= N rows uses sampled update
-    @GiantSamplePercent  tinyint       = 50,          -- Sample percent when table is >= N rows
-    @LowSamplePctCutoff  decimal(5,2)  = 5.00,        -- Low sample cutoff for NORECOMPUTE recommendation
+    @LowSamplePctCutoff  decimal(5,2)  = 5.00,        -- Low sample cutoff for flagging under-sampled stats
     @SkewRatioCutoff     decimal(10,2) = 100.00,      -- Histogram max/avg ratio considered skewed
     @OnlySuspicious      bit           = 0,           -- 1 = only rows that may need action (DETAIL only)
     @IncludeSkewAnalysis bit           = 1,           -- 0 = skip histogram analysis (DETAIL only)
@@ -15,12 +13,10 @@ AS
 /*************************************************************************************************
 AUTHOR: Andy Mallon
 CREATED: 20260629
-    Read-only statistics recommendation report for a target database.
-    Applies the DB-747 policy model:
-    * Tables below @RowCountThreshold => FULLSCAN recommendation
-    * Tables at/above @RowCountThreshold => SAMPLE @GiantSamplePercent recommendation
-    * Low sample percentages => NORECOMPUTE candidate
-    * High histogram skew ratio => filtered statistics review candidate
+    Read-only statistics report for a target database. Surfaces per-statistic and per-table
+    sampling and histogram-skew detail so you can spot under-sampled or skewed statistics.
+    Recommendation/remediation logic (sample policy, NORECOMPUTE candidates, fix scripts)
+    is intentionally handled elsewhere -- this proc just reports the raw picture.
 
     @Mode controls the output granularity. Synonyms are accepted so you can use whichever reads best:
     * DETAIL (or STAT)  - One row per statistic, including per-stat sampling and histogram skew.
@@ -35,9 +31,7 @@ PARAMETERS
 * @SchemaName - Optional schema filter.
 * @ObjectName - Optional table filter.
 * @StatisticName - Optional statistic/index filter. Only meaningful for DETAIL.
-* @RowCountThreshold - Row count breakpoint for sample policy.
-* @GiantSamplePercent - Sample percentage for tables at or above the breakpoint.
-* @LowSamplePctCutoff - Threshold for low observed sample percentage.
+* @LowSamplePctCutoff - Threshold for flagging a low observed sample percentage.
 * @SkewRatioCutoff - Threshold for max-step-to-avg-step histogram ratio. Only used by DETAIL.
 * @OnlySuspicious - Return only rows with low sample or non-zero modification counter. Only used by DETAIL.
 * @IncludeSkewAnalysis - Include histogram analysis (heavier DMV access). Only used by DETAIL.
@@ -45,36 +39,36 @@ PARAMETERS
 
 EXAMPLES:
 -- Whole database, per-table rollup (the default):
--- EXEC dbo.Check_StatsDetails @DbName = N'Mobo';
+-- EXEC dbo.Check_StatsDetails @DbName = N'AMtwo';
 
 -- Per-statistic detail for the whole database:
--- EXEC dbo.Check_StatsDetails @DbName = N'Mobo', @Mode = 'DETAIL';
+-- EXEC dbo.Check_StatsDetails @DbName = N'AMtwo', @Mode = 'DETAIL';
 
 -- Both result sets at once:
--- EXEC dbo.Check_StatsDetails @DbName = N'Mobo', @Mode = 'ALL';
+-- EXEC dbo.Check_StatsDetails @DbName = N'AMtwo', @Mode = 'ALL';
 
 -- Single table, per-statistic detail:
 -- EXEC dbo.Check_StatsDetails
---     @DbName = N'Mobo',
+--     @DbName = N'AMtwo',
 --     @Mode = 'DETAIL',
 --     @SchemaName = N'dbo',
 --     @ObjectName = N'Order';
 
 -- Single statistic and skip skew analysis:
 -- EXEC dbo.Check_StatsDetails
---     @DbName = N'Mobo',
+--     @DbName = N'AMtwo',
 --     @Mode = 'DETAIL',
 --     @StatisticName = N'CUIX_OpenOrder',
 --     @IncludeSkewAnalysis = 0;
 
 -- Return only suspicious rows:
 -- EXEC dbo.Check_StatsDetails
---     @DbName = N'Mobo',
+--     @DbName = N'AMtwo',
 --     @Mode = 'DETAIL',
 --     @OnlySuspicious = 1;
 
 -- Print generated SQL only:
--- EXEC dbo.Check_StatsDetails @DbName = N'Mobo', @Debug = 1;
+-- EXEC dbo.Check_StatsDetails @DbName = N'AMtwo', @Debug = 1;
 
 **************************************************************************************************
 MODIFICATIONS:
@@ -82,6 +76,8 @@ MODIFICATIONS:
     20260629 - AM2 - Rename procedure to dbo.Check_StatsDetails to match filename.
     20260629 - AM2 - Add @Mode (DETAIL/STAT, ROLLUP/TABLE, ALL); promote the table-level rollup
                      from an ad-hoc comment into a real, parameterized result set.
+    20260629 - AM2 - Remove RecSamplePolicy/RecAction/FixSql columns (recommendation logic moves
+                     elsewhere); drop the now-unused @RowCountThreshold/@GiantSamplePercent params.
 **************************************************************************************************
     This code is licensed as part of Andy Mallon's DBA Database.
     https://github.com/amtwo/dba-database/blob/master/LICENSE
@@ -284,17 +280,13 @@ BEGIN
     -- DETAIL-only parameters; passing them anyway is harmless and keeps the call site simple.
     EXEC sys.sp_executesql
         @sql,
-        N'@N bigint,
-          @GiantPct tinyint,
-          @LowCutoff decimal(5,2),
+        N'@LowCutoff decimal(5,2),
           @SkewCutoff decimal(10,2),
           @OnlySuspicious bit,
           @IncludeSkew bit,
           @SchemaName sysname,
           @ObjectName sysname,
           @StatisticName sysname',
-        @N              = @RowCountThreshold,
-        @GiantPct       = @GiantSamplePercent,
         @LowCutoff      = @LowSamplePctCutoff,
         @SkewCutoff     = @SkewRatioCutoff,
         @OnlySuspicious = @OnlySuspicious,

--- a/stored-procedures/dbo.Check_StatsDetails.sql
+++ b/stored-procedures/dbo.Check_StatsDetails.sql
@@ -1,6 +1,6 @@
 CREATE OR ALTER PROCEDURE dbo.Check_StatsDetails
     @DbName              sysname,
-    @Mode                varchar(10)   = 'ROLLUP',     -- DETAIL, ROLLUP, or ALL (see header)
+    @Mode                varchar(10)   = 'ROLLUP',     -- DETAIL/STAT, ROLLUP/TABLE, or ALL (see header)
     @SchemaName          sysname       = NULL,        -- Filter by schema
     @ObjectName          sysname       = NULL,        -- Filter by table
     @StatisticName       sysname       = NULL,        -- Filter by statistic/index name (DETAIL only)
@@ -22,16 +22,16 @@ CREATED: 20260629
     * Low sample percentages => NORECOMPUTE candidate
     * High histogram skew ratio => filtered statistics review candidate
 
-    @Mode controls the output granularity:
-    * DETAIL - One row per statistic, including per-stat sampling and histogram skew.
-    * ROLLUP - One row per table, collapsing the per-stat detail to spot tables where
-               one stat is under-sampled while its siblings are fine (an index-level
-               NORECOMPUTE candidate). This is the default.
-    * ALL    - Returns both result sets (DETAIL first, then ROLLUP).
+    @Mode controls the output granularity. Synonyms are accepted so you can use whichever reads best:
+    * DETAIL (or STAT)  - One row per statistic, including per-stat sampling and histogram skew.
+    * ROLLUP (or TABLE) - One row per table, collapsing the per-stat detail to spot tables where
+                          one stat is under-sampled while its siblings are fine (an index-level
+                          NORECOMPUTE candidate). This is the default.
+    * ALL               - Returns both result sets (DETAIL first, then ROLLUP).
 
 PARAMETERS
 * @DbName - Target database name.
-* @Mode - Output granularity: DETAIL (per-statistic), ROLLUP (per-table), or ALL (both). Defaults to ROLLUP.
+* @Mode - Output granularity: DETAIL/STAT (per-statistic), ROLLUP/TABLE (per-table), or ALL (both). Defaults to ROLLUP.
 * @SchemaName - Optional schema filter.
 * @ObjectName - Optional table filter.
 * @StatisticName - Optional statistic/index filter. Only meaningful for DETAIL.
@@ -80,8 +80,8 @@ EXAMPLES:
 MODIFICATIONS:
     20260629 - AM2 - Normalize formatting/comments to current repository style.
     20260629 - AM2 - Rename procedure to dbo.Check_StatsDetails to match filename.
-    20260629 - AM2 - Add @Mode (DETAIL/ROLLUP/ALL); promote the table-level rollup from an
-                     ad-hoc comment into a real, parameterized result set.
+    20260629 - AM2 - Add @Mode (DETAIL/STAT, ROLLUP/TABLE, ALL); promote the table-level rollup
+                     from an ad-hoc comment into a real, parameterized result set.
 **************************************************************************************************
     This code is licensed as part of Andy Mallon's DBA Database.
     https://github.com/amtwo/dba-database/blob/master/LICENSE
@@ -97,13 +97,23 @@ BEGIN
         RETURN;
     END;
 
-    -- Normalize @Mode so callers don't get tripped up by case or stray whitespace,
-    -- then validate it against the supported set before doing any work.
+    -- Normalize @Mode so callers don't get tripped up by case or stray whitespace.
     SET @Mode = UPPER(LTRIM(RTRIM(@Mode)));
 
+    -- Collapse the friendly synonyms onto their canonical values, so the build logic
+    -- below only ever has to reason about DETAIL, ROLLUP, or ALL:
+    --   STAT  is an alias for DETAIL (per-statistic grain)
+    --   TABLE is an alias for ROLLUP (per-table grain)
+    SET @Mode = CASE @Mode
+                    WHEN 'STAT'  THEN 'DETAIL'
+                    WHEN 'TABLE' THEN 'ROLLUP'
+                    ELSE @Mode
+                END;
+
+    -- Validate against the canonical set before doing any work.
     IF @Mode NOT IN ('DETAIL', 'ROLLUP', 'ALL')
     BEGIN
-        RAISERROR('@Mode must be one of: DETAIL, ROLLUP, or ALL.', 16, 1);
+        RAISERROR('@Mode must be one of: DETAIL (or STAT), ROLLUP (or TABLE), or ALL.', 16, 1);
         RETURN;
     END;
 
@@ -302,7 +312,6 @@ BEGIN
     IF @Debug = 1
     BEGIN
         EXEC dbo.Debug_Print @DebugMessage = @sql;
-        RETURN;
     END;
 
     -- One unified parameter list serves both statements. ROLLUP simply doesn't reference the

--- a/stored-procedures/dbo.Cleanup_TableByID.sql
+++ b/stored-procedures/dbo.Cleanup_TableByID.sql
@@ -67,7 +67,7 @@ SELECT @sql = N'SELECT @ChunkID = MIN(' + QUOTENAME(@IDColumnName) + N'), @MaxID
 
 IF @Debug = 1
 BEGIN
-    PRINT @sql;
+    EXEC dbo.Debug_Print @DebugMessage = @sql;
 END;
 -- Even in Debug mode, we run this to get min/max values. We're not changing data yet.
 EXEC sp_executesql @stmt = @sql, @params = N'@RetainDays int, @ChunkID bigint OUT, @MaxID bigint OUT', @RetainDays = @RetainDays, @ChunkID = @ChunkID OUT, @MaxID = @MaxID OUT;
@@ -89,7 +89,7 @@ WHILE @ChunkID < @MaxID
         --if we're in debug mode, just print the DELETE statement
         ELSE
             BEGIN
-                PRINT @sql;
+                EXEC dbo.Debug_Print @DebugMessage = @sql;
             END;
     END;
 GO

--- a/stored-procedures/dbo.Debug_Print.sql
+++ b/stored-procedures/dbo.Debug_Print.sql
@@ -1,0 +1,101 @@
+CREATE OR ALTER PROCEDURE dbo.Debug_Print
+    @DebugMessage nvarchar(max)           -- Long message to PRINT in <=4000-char chunks
+AS
+/*************************************************************************************************
+AUTHOR: Andy Mallon
+CREATED: 20260629
+    PRINT tops out at 4000 unicode characters, which makes it useless for dumping long debug
+    strings (assembled dynamic SQL, big diagnostic blobs, etc) in one shot. This procedure walks
+    the message and PRINTs it in chunks of up to 4000 characters.
+
+    Rather than slicing blindly at 4000 -- which splits words and lines mid-stream -- each chunk
+    breaks on a whitespace character found in its last ~200 characters. We look for a break in
+    priority order, always choosing the candidate closest to the end of the printable chunk:
+    * New line (CR, LF, or CRLF) -- break at the line ending nearest the end of the chunk.
+    * Tab -- if no new line is in the window, break at the last tab.
+    * Space -- if neither is present, break at the last space.
+    * If the window has no whitespace at all, fall back to a hard 4000-character break.
+
+    The break character is kept at the tail of its chunk, so no characters are ever dropped --
+    the concatenation of every chunk reproduces @DebugMessage exactly.
+
+PARAMETERS
+* @DebugMessage - The (potentially very long) message to print.
+
+EXAMPLES:
+-- Print a long blob of dynamic SQL without truncating at 4000 chars:
+-- EXEC dbo.Debug_Print @DebugMessage = @sql;
+
+**************************************************************************************************
+MODIFICATIONS:
+    20260629 - AM2 - Break chunks on whitespace (new line, then tab, then space) within the last
+                     ~200 characters instead of slicing mid-word.
+**************************************************************************************************
+    This code is licensed as part of Andy Mallon's DBA Database.
+    https://github.com/amtwo/dba-database/blob/master/LICENSE
+    ©2014-2026 ● Andy Mallon ● am2.co
+*************************************************************************************************/
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE
+        @pos         int = 1,                       -- Start of the current chunk (1-based)
+        @len         int = LEN(@DebugMessage),
+        @maxChunk    int = 4000,                    -- PRINT's hard unicode limit
+        @windowLen   int = 200,                     -- Tail of the chunk we search for whitespace
+        @searchStart int,
+        @revWindow   nvarchar(200),
+        @lfOffset    int,
+        @crOffset    int,
+        @breakOffset int,                           -- Offset of the break char from the END of the window
+        @chunkLen    int;
+
+    WHILE @pos <= @len
+    BEGIN
+        -- If everything left fits in a single PRINT, emit it and we're done.
+        IF @len - @pos + 1 <= @maxChunk
+        BEGIN
+            PRINT SUBSTRING(@DebugMessage, @pos, @maxChunk);
+            BREAK;
+        END;
+
+        -- More than 4000 characters remain, so we have to split. Search the last @windowLen
+        -- characters of this 4000-char chunk for a whitespace break. Reversing the window once
+        -- lets a single CHARINDEX per candidate return the occurrence *closest to the end* of
+        -- the chunk: the smaller the CHARINDEX, the nearer the char is to the chunk's tail.
+        SET @searchStart = @pos + @maxChunk - @windowLen;
+        SET @revWindow   = REVERSE(SUBSTRING(@DebugMessage, @searchStart, @windowLen));
+
+        -- Priority: new line -> tab -> space. A new line may be CR, LF, or CRLF, so check both
+        -- characters and take whichever sits closest to the end of the chunk (smallest offset in
+        -- the reversed window). For CRLF the LF is nearer the tail, so we naturally break after
+        -- the full line ending and keep both characters with the chunk.
+        SET @lfOffset = CHARINDEX(NCHAR(10), @revWindow);    -- LF
+        SET @crOffset = CHARINDEX(NCHAR(13), @revWindow);    -- CR
+
+        SET @breakOffset =
+            CASE
+                WHEN @lfOffset > 0 AND @crOffset > 0 THEN
+                    CASE WHEN @lfOffset < @crOffset THEN @lfOffset ELSE @crOffset END
+                ELSE @lfOffset + @crOffset    -- one (or both) is 0, so this is the non-zero one
+            END;
+
+        IF @breakOffset = 0
+            SET @breakOffset = CHARINDEX(NCHAR(9), @revWindow);     -- Tab
+
+        IF @breakOffset = 0
+            SET @breakOffset = CHARINDEX(NCHAR(32), @revWindow);    -- Space
+
+        IF @breakOffset = 0
+            -- No whitespace in the window: nothing to break on, so take the full 4000.
+            SET @chunkLen = @maxChunk;
+        ELSE
+            -- Keep the break char at the tail of this chunk. Its position from the start of the
+            -- chunk is (@maxChunk - @breakOffset + 1), since @breakOffset counts from the end.
+            SET @chunkLen = @maxChunk - @breakOffset + 1;
+
+        PRINT SUBSTRING(@DebugMessage, @pos, @chunkLen);
+        SET @pos = @pos + @chunkLen;
+    END;
+END;
+GO

--- a/stored-procedures/dbo.Find_StringInModules.sql
+++ b/stored-procedures/dbo.Find_StringInModules.sql
@@ -175,7 +175,7 @@ SELECT [database]     = DB_NAME(),
     IF @debug = 1
     BEGIN
       RAISERROR(N'Running dynamic SQL on %s:', 1, 0, @db);
-      PRINT @sql;
+      EXEC dbo.Debug_Print @DebugMessage = @sql;
     END
     ELSE
     BEGIN
@@ -243,7 +243,7 @@ SELECT [database]     = DB_NAME(),
     IF @debug = 1
     BEGIN
       PRINT N'Running this for jobs:';
-      PRINT @sql;
+      EXEC dbo.Debug_Print @DebugMessage = @sql;
     END
     ELSE
     BEGIN

--- a/stored-procedures/dbo.PlanGuide_SetHintForProcedureStatement.sql
+++ b/stored-procedures/dbo.PlanGuide_SetHintForProcedureStatement.sql
@@ -145,7 +145,7 @@ BEGIN
         END;
         IF (@Debug = 1)
         BEGIN
-            PRINT @sql;
+            EXEC dbo.Debug_Print @DebugMessage = @sql;
             PRINT '@PlanGuideName = ' + @PlanGuideName;
         END;
     END;
@@ -161,7 +161,7 @@ BEGIN
 
     IF (@Debug = 1)
     BEGIN
-        PRINT @sql;
+        EXEC dbo.Debug_Print @DebugMessage = @sql;
     END;
     IF (@Debug = 0)
     BEGIN

--- a/stored-procedures/dbo.Repl_AddArticle.sql
+++ b/stored-procedures/dbo.Repl_AddArticle.sql
@@ -103,7 +103,7 @@ IF @Debug = 0
                 @UpdateCommand      = @UpdateCommand,
                 @DeleteCommand      = @DeleteCommand;
 ELSE
-    PRINT @sql;
+    EXEC dbo.Debug_Print @DebugMessage = @sql;
     PRINT N'    Publication:   ' + @PublicationName
     PRINT N'    Article:       ' + @ArticleName
     PRINT N'    SchemaOption:  ' + CONVERT(nvarchar(max), @SchemaOption)

--- a/stored-procedures/dbo.Repl_CreatePublication.sql
+++ b/stored-procedures/dbo.Repl_CreatePublication.sql
@@ -64,7 +64,7 @@ SET @sql = @sql + N'EXEC sp_replicationdboption
 IF @Debug = 0
     EXEC sp_executesql @sql;
 ELSE
-    PRINT @sql;
+    EXEC dbo.Debug_Print @DebugMessage = @sql;
 
 -- Adding the transactional publication
 SET @sql = 'USE [' + @PubDbName + '];' + CHAR(10) + CHAR(13);
@@ -98,7 +98,7 @@ SET @sql = @sql + N'EXEC sp_addpublication
 IF @Debug = 0
     EXEC sp_executesql @sql;
 ELSE
-    PRINT @sql;
+    EXEC dbo.Debug_Print @DebugMessage = @sql;
 
 
 -- Set snapshot agent to run on a schedule (hourly) to make sure new/changed articles 
@@ -123,7 +123,7 @@ SET @sql = @sql + 'exec sp_addpublication_snapshot
 IF @Debug = 0
     EXEC sp_executesql @sql;
 ELSE
-    PRINT @sql;
+    EXEC dbo.Debug_Print @DebugMessage = @sql;
 
 
 --If DB is in an AG, update distributor to know that
@@ -136,7 +136,7 @@ BEGIN
     IF @Debug = 0
         EXEC sp_executesql @sql;
     ELSE
-        PRINT @sql;
+        EXEC dbo.Debug_Print @DebugMessage = @sql;
 END;
 GO
 

--- a/stored-procedures/dbo.Repl_CreateSubscription.sql
+++ b/stored-procedures/dbo.Repl_CreateSubscription.sql
@@ -45,7 +45,7 @@ SET @sql = @sql + 'EXEC sp_addsubscription
 IF @Debug = 0
     EXEC sp_executesql @sql;
 ELSE
-    PRINT @sql;
+    EXEC dbo.Debug_Print @DebugMessage = @sql;
 
 --Create the agent job
 SET @sql = 'USE [' + @PubDbName + ']' + CHAR(10) + CHAR(13);
@@ -73,7 +73,7 @@ SET @sql = @sql + 'EXEC sp_addpushsubscription_agent
 IF @Debug = 0
     EXEC sp_executesql @sql;
 ELSE
-    PRINT @sql;
+    EXEC dbo.Debug_Print @DebugMessage = @sql;
 GO
 
 

--- a/stored-procedures/dbo.Set_AGReadOnlyRouting.sql
+++ b/stored-procedures/dbo.Set_AGReadOnlyRouting.sql
@@ -209,6 +209,6 @@ IF @Debug = 0
   END
 ELSE
   BEGIN
-    PRINT @sql;
+    EXEC dbo.Debug_Print @DebugMessage = @sql;
   END;
 GO

--- a/stored-procedures/dbo.Set_StatisticsNorecomputeByTable.sql
+++ b/stored-procedures/dbo.Set_StatisticsNorecomputeByTable.sql
@@ -77,7 +77,7 @@ BEGIN
       
         IF @Debug = 1
         BEGIN
-            PRINT @sql;
+            EXEC dbo.Debug_Print @DebugMessage = @sql;
         END;
 
         INSERT INTO #Results (DbName, SchemaName, ObjectName, StatisticsList)
@@ -106,7 +106,7 @@ BEGIN
       
         IF @Debug = 1
         BEGIN
-            PRINT @sql;
+            EXEC dbo.Debug_Print @DebugMessage = @sql;
         END;
 
         INSERT INTO #Results (DbName, SchemaName, ObjectName, StatisticsList)
@@ -134,7 +134,7 @@ FROM #Results;
 
 IF @Debug = 1
 BEGIN
-    PRINT @sql;
+    EXEC dbo.Debug_Print @DebugMessage = @sql;
 END;
 
 IF @Debug = 0

--- a/stored-procedures/dbo.sp_Get_BaseTableList.sql
+++ b/stored-procedures/dbo.sp_Get_BaseTableList.sql
@@ -5,12 +5,12 @@ GO
 --Instead: if it doesn't exist, create a stub & grant permissions, then alter the sproc to use the correct code.
 IF OBJECT_ID('sp_get_basetable_list', 'P') IS  NULL
 BEGIN
-	--do this in dynamic SQL so CREATE PROCEDURE can be nested in this IF block
-	EXEC ('CREATE PROCEDURE dbo.sp_get_basetable_list AS SELECT 1')
-	--mark it as a system object
-	--EXEC sp_MS_marksystemobject sp_get_basetable_list
-	--grant permission to the whole world
-	--GRANT EXECUTE ON sp_get_basetable_list to PUBLIC
+    --do this in dynamic SQL so CREATE PROCEDURE can be nested in this IF block
+    EXEC ('CREATE PROCEDURE dbo.sp_get_basetable_list AS SELECT 1')
+    --mark it as a system object
+    --EXEC sp_MS_marksystemobject sp_get_basetable_list
+    --grant permission to the whole world
+    --GRANT EXECUTE ON sp_get_basetable_list to PUBLIC
 END
 GO
 
@@ -23,25 +23,25 @@ AS
 AUTHOR: Andy Mallon
 CREATED: 20140228
        This procedure can be called two ways:
-	   1) by passing a view/synonym/table name to the @object_name parameter
-	   2) by creating & populating #tables (matching schema at start of sproc) then calling the 
-	      sproc with that table populated.
+       1) by passing a view/synonym/table name to the @object_name parameter
+       2) by creating & populating #tables (matching schema at start of sproc) then calling the 
+          sproc with that table populated.
 
-	   If option 1 is used to call the sproc, the table list will be returned in the form
-	   of a result set.
-	   If option 2 is used to call the sproc, then #tables will be populated with the physical 
-	   tables.
-	   
-	   For the object(s) passed to this sproc, look up the physical tables behind it.
-	   * If a synonym is passed, return the base table of that synonym
-	   * If a view is passed, return ALL the base tables of that view
-	   * If a table is passed, return the table itself
+       If option 1 is used to call the sproc, the table list will be returned in the form
+       of a result set.
+       If option 2 is used to call the sproc, then #tables will be populated with the physical 
+       tables.
+       
+       For the object(s) passed to this sproc, look up the physical tables behind it.
+       * If a synonym is passed, return the base table of that synonym
+       * If a view is passed, return ALL the base tables of that view
+       * If a table is passed, return the table itself
 
-	   Lookup is recursive and only ends when #tables contains only tables.
+       Lookup is recursive and only ends when #tables contains only tables.
 
 PARAMETERS
 * @object_name - Optional - accept three-part object name (Database.Schema.Table)
-		- If not provided, #tables should exist & be populated, otherwise, raiserror
+        - If not provided, #tables should exist & be populated, otherwise, raiserror
 **************************************************************************************************
 MODIFICATIONS:
        YYYYMMDDD - Initials - Description of changes
@@ -52,96 +52,102 @@ MODIFICATIONS:
 *************************************************************************************************/
 
 SET NOCOUNT ON
-	--If #tables doesn't exist, create it, and populate it from the input param
-	
-	IF (object_id('tempdb..#tables') IS NULL)
-	BEGIN
-		IF @object_name IS NULL
-			RAISERROR ('No table(s) provided.',16,1)
-		CREATE TABLE #tables (DbName sysname, SchemaName sysname, TableName sysname, ObjType char(2) CONSTRAINT pk_tables PRIMARY KEY (DbName, SchemaName, TableName))
-		INSERT INTO #tables (DbName, SchemaName, TableName)
-		SELECT COALESCE(parsename(@object_name,3),db_name()),
-			COALESCE(parsename(@object_name,2),schema_name()),
-			parsename(@object_name,1)
-	END
+    --If #tables doesn't exist, create it, and populate it from the input param
+    
+    IF (object_id('tempdb..#tables') IS NULL)
+    BEGIN
+        IF @object_name IS NULL
+            RAISERROR ('No table(s) provided.',16,1)
+        CREATE TABLE #tables (DbName sysname, SchemaName sysname, TableName sysname, ObjType char(2) CONSTRAINT pk_tables PRIMARY KEY (DbName, SchemaName, TableName))
+        INSERT INTO #tables (DbName, SchemaName, TableName)
+        SELECT COALESCE(parsename(@object_name,3),db_name()),
+            COALESCE(parsename(@object_name,2),schema_name()),
+            parsename(@object_name,1)
+    END
 
 
-	DECLARE @sql nvarchar(2070)
-	DECLARE @DbName varchar(256)
-	DECLARE @SchemaName varchar(256)
-	DECLARE @TableName varchar(256)
-	DECLARE @ObjType char(2)
-	
-	WHILE EXISTS(SELECT 1 FROM #tables WHERE COALESCE(ObjType,'x') <> 'U')
-	BEGIN
-		DECLARE db_cur CURSOR FOR
-			SELECT DISTINCT DbName FROM #tables
+    DECLARE @sql nvarchar(2070)
+    DECLARE @DbName varchar(256)
+    DECLARE @SchemaName varchar(256)
+    DECLARE @TableName varchar(256)
+    DECLARE @ObjType char(2)
+    
+    WHILE EXISTS(SELECT 1 FROM #tables WHERE COALESCE(ObjType,'x') <> 'U')
+    BEGIN
+        DECLARE db_cur CURSOR FOR
+            SELECT DISTINCT DbName FROM #tables
 
-		OPEN db_cur
-		FETCH NEXT FROM db_cur INTO @DbName
+        OPEN db_cur
+        FETCH NEXT FROM db_cur INTO @DbName
 
-		WHILE @@FETCH_STATUS = 0
-		BEGIN
-			-- Get the object types for everything in this DB
-			SET @sql = N'UPDATE t SET ObjType = o.type FROM #tables t JOIN ' + @DbName + '.sys.objects o ON o.schema_id = schema_id(t.SchemaName) AND o.name = t.TableName WHERE t.DbName = ''' + @DbName + ''''
-			IF @debug = 1
-				PRINT @sql
-			EXEC (@sql)
+        WHILE @@FETCH_STATUS = 0
+        BEGIN
+            -- Get the object types for everything in this DB
+            SET @sql = N'UPDATE t SET ObjType = o.type FROM #tables t JOIN ' + @DbName + '.sys.objects o ON o.schema_id = schema_id(t.SchemaName) AND o.name = t.TableName WHERE t.DbName = ''' + @DbName + ''''
+            IF @debug = 1
+            BEGIN
+                EXEC dbo.Debug_Print @DebugMessage = @sql
+            END
+            EXEC (@sql)
 
-			IF EXISTS (SELECT 1 FROM #tables WHERE DbName = @DbName AND ObjType IS NULL)
-			BEGIN
-				PRINT 'Unable to determine object type for one or more objects.'
-				DELETE FROM #tables WHERE DbName = @DbName AND ObjType IS NULL
-			END
+            IF EXISTS (SELECT 1 FROM #tables WHERE DbName = @DbName AND ObjType IS NULL)
+            BEGIN
+                PRINT 'Unable to determine object type for one or more objects.'
+                DELETE FROM #tables WHERE DbName = @DbName AND ObjType IS NULL
+            END
 
-			DECLARE tab_cur CURSOR FOR
-				SELECT SchemaName, TableName, ObjType
-				FROM #tables
-				WHERE DbName = @DbName
+            DECLARE tab_cur CURSOR FOR
+                SELECT SchemaName, TableName, ObjType
+                FROM #tables
+                WHERE DbName = @DbName
 
-			OPEN tab_cur
-			FETCH NEXT FROM tab_cur INTO @SchemaName, @TableName, @ObjType
-			WHILE @@FETCH_STATUS = 0
-			BEGIN
-				IF (@ObjType ='SN') 
-				BEGIN
-					--Its not a table. Delete the current row & replace with object(s) it references
-					DELETE #tables WHERE DbName = @DbName AND SchemaName = @SchemaName AND TableName = @TableName
-					SET @sql = N'INSERT INTO #tables (DbName, SchemaName, TableName) SELECT COALESCE(PARSENAME(base_object_name,3),db_name()), '
-							+ 'COALESCE(PARSENAME(base_object_name,2),schema_name()), PARSENAME(base_object_name,1)  FROM ' + @DbName 
-								+ '.sys.synonyms WHERE name = ''' + @TableName + ''' AND schema_id = schema_id(''' + @SchemaName + ''')'
-					IF @debug = 1
-						PRINT @sql
-					EXEC (@sql)
-				END 
-				
-				ELSE IF (@ObjType <> 'U')
-				BEGIN
-					--Its not a table. Delete the current row & replace with object(s) it references
-					DELETE #tables WHERE DbName = @DbName AND SchemaName = @SchemaName AND TableName = @TableName
-					SET @sql = N'INSERT INTO #tables (DbName, SchemaName, TableName) SELECT DISTINCT COALESCE(referenced_database_name,''' 
-							+ @DbName + '''), COALESCE(referenced_schema_name,''' + @SchemaName + '''), referenced_entity_name FROM ' + QUOTENAME(@DbName) 
-							+ '.sys.dm_sql_referenced_entities (''' + QUOTENAME(@SchemaName) + '.' + QUOTENAME(@TableName) + ''',''OBJECT'') r '
-							+ 'WHERE NOT EXISTS(SELECT 1 FROM #tables t WHERE t.DbName = COALESCE(r.referenced_database_name,''' + @DbName + ''') AND '
-							+ 't.SchemaName = COALESCE(r.referenced_schema_name,''' + @SchemaName + ''') AND t.TableName = r.referenced_entity_name)'
-					IF @debug = 1
-						PRINT @sql
-					EXEC (@sql)
-				END
-				FETCH NEXT FROM tab_cur INTO @SchemaName, @TableName, @ObjType
-			END
+            OPEN tab_cur
+            FETCH NEXT FROM tab_cur INTO @SchemaName, @TableName, @ObjType
+            WHILE @@FETCH_STATUS = 0
+            BEGIN
+                IF (@ObjType ='SN') 
+                BEGIN
+                    --Its not a table. Delete the current row & replace with object(s) it references
+                    DELETE #tables WHERE DbName = @DbName AND SchemaName = @SchemaName AND TableName = @TableName
+                    SET @sql = N'INSERT INTO #tables (DbName, SchemaName, TableName) SELECT COALESCE(PARSENAME(base_object_name,3),db_name()), '
+                            + 'COALESCE(PARSENAME(base_object_name,2),schema_name()), PARSENAME(base_object_name,1)  FROM ' + @DbName 
+                                + '.sys.synonyms WHERE name = ''' + @TableName + ''' AND schema_id = schema_id(''' + @SchemaName + ''')'
+                    IF @debug = 1
+                    BEGIN
+                        EXEC dbo.Debug_Print @DebugMessage = @sql
+                    END
+                    EXEC (@sql)
+                END 
+                
+                ELSE IF (@ObjType <> 'U')
+                BEGIN
+                    --Its not a table. Delete the current row & replace with object(s) it references
+                    DELETE #tables WHERE DbName = @DbName AND SchemaName = @SchemaName AND TableName = @TableName
+                    SET @sql = N'INSERT INTO #tables (DbName, SchemaName, TableName) SELECT DISTINCT COALESCE(referenced_database_name,''' 
+                            + @DbName + '''), COALESCE(referenced_schema_name,''' + @SchemaName + '''), referenced_entity_name FROM ' + QUOTENAME(@DbName) 
+                            + '.sys.dm_sql_referenced_entities (''' + QUOTENAME(@SchemaName) + '.' + QUOTENAME(@TableName) + ''',''OBJECT'') r '
+                            + 'WHERE NOT EXISTS(SELECT 1 FROM #tables t WHERE t.DbName = COALESCE(r.referenced_database_name,''' + @DbName + ''') AND '
+                            + 't.SchemaName = COALESCE(r.referenced_schema_name,''' + @SchemaName + ''') AND t.TableName = r.referenced_entity_name)'
+                    IF @debug = 1
+                    BEGIN
+                        EXEC dbo.Debug_Print @DebugMessage = @sql
+                    END
+                    EXEC (@sql)
+                END
+                FETCH NEXT FROM tab_cur INTO @SchemaName, @TableName, @ObjType
+            END
 
-			CLOSE tab_cur
-			DEALLOCATE tab_cur
-			FETCH NEXT FROM db_cur INTO @DbName
-		END
-		CLOSE db_cur
-		DEALLOCATE db_cur
-	END
+            CLOSE tab_cur
+            DEALLOCATE tab_cur
+            FETCH NEXT FROM db_cur INTO @DbName
+        END
+        CLOSE db_cur
+        DEALLOCATE db_cur
+    END
 
-	IF (@object_name IS NOT NULL)
-		SELECT DbName, SchemaName, TableName FROM #tables
+    IF (@object_name IS NOT NULL)
+        SELECT DbName, SchemaName, TableName FROM #tables
 
-	GO
+    GO
 
 


### PR DESCRIPTION
## What does this change?

Adds a new reusable proc, **`dbo.Debug_Print`**, for `PRINT`ing long debug strings. `PRINT` truncates at 4000 unicode characters, so dumping assembled dynamic SQL gets cut off or split mid-word. `Debug_Print` walks the message in <=4000-char chunks but breaks each chunk on whitespace in its last ~200 characters — preferring a new line (CR/LF/CRLF), then a tab, then a space, falling back to a hard 4000 cut only when the window has no whitespace. The break character stays with its chunk, so the chunks reassemble to the original exactly.

It then routes the repo's existing debug-print blocks through it:

- **`Check_StatsDetails`** uses `Debug_Print` for its `@Debug` dump.
- Existing debug-gated `PRINT @sql` blocks now call `Debug_Print` in: `Cleanup_TableByID`, `Find_StringInModules`, `PlanGuide_SetHintForProcedureStatement`, `Repl_AddArticle`, `Repl_CreatePublication`, `Repl_CreateSubscription`, `Set_AGReadOnlyRouting`, `Set_StatisticsNorecomputeByTable`, `sp_Get_BaseTableList`.
- **`Check_FileSize`** and **`Check_LogVLF`** gained a `@Debug bit = 0` parameter; their previously *unconditional* `PRINT @sql` is now gated behind `@Debug` and routed through `Debug_Print`.
- **`Check_QueryStoreRegressedQueries`** gates its previously-unconditional print behind `@Debug`.
- **`sp_Get_BaseTableList`** wraps its debug prints in `BEGIN/END` and converts the file's tab indentation to 4 spaces (per CONTRIBUTING.md — this file is named there as a tab offender).

**Behavior change worth calling out:** `Check_FileSize` and `Check_LogVLF` used to print their dynamic SQL on every run. That output now only appears with `@Debug = 1`.

## Related issue

No separate issue — small internal-tooling refactor on top of the recently-added `Check_StatsDetails`.

## How did you test it?

* **SQL Server version / edition tested against:** _Not yet run against a live instance._
* **Installed cleanly via `Install-LatestDbaDatabase.ps1` (and a second time, to confirm it's idempotent):** [ ] not yet — needs to be run before merge
* **Before/after output, or a sample call + result:**

```
-- Pending: EXEC dbo.Check_StatsDetails @DbName = N'...', @Debug = 1;
--          to confirm Debug_Print chunks the long dynamic SQL on whitespace
--          without truncating or splitting words.
```

> Heads-up: the install/idempotency run and before/after capture are still outstanding. Flagging honestly rather than checking the box — happy to run these and paste results before merge.

## Checklist

* [x] Follows the conventions in [CONTRIBUTING.md](../CONTRIBUTING.md) (`CREATE OR ALTER`, flowerbox header, PascalCase params, lowercase data types, 4-space indent, `SET NOCOUNT ON;`)
* [x] One object per file, filename matches the object name (`dbo.Debug_Print.sql`)
* [x] The header comment block is filled in (description, parameters, examples, modifications)
* [x] Re-running the script is safe (idempotent — `CREATE OR ALTER`; `sp_Get_BaseTableList` keeps its stub-then-ALTER pattern, which CONTRIBUTING.md preserves for system-marked `sp_` procs in master)